### PR TITLE
Add first collectd-cvmfs implementation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
 include NEWS.txt
+include resources/collectdcvmfs.db

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,52 @@
 Collectd Module for CvmFS
 =========================
 
+Configuration
+-------------
+
+Example::
+
+    <Plugin "python">
+
+      Import "collectdcvmfs"
+
+      <Module "collectdcvmfs">
+        Repo "alice.cern.ch" "atlas.cern.ch"
+        Repo "ams.cern.ch"
+
+        MountTime True
+        Memory True
+
+        Attribute ndownload nioerr
+        Attribute usedfd
+
+        Interval "300"
+      </Module>
+
+    </Plugin>
+
+
+* ``Repo``: cvmfs repository to monitor.
+* ``MountTime``: boolean value to specify whether mount time should be reported or not.
+* ``Memory``: boolean value to specify whether the memory footprint should be reported or not.
+* ``Attribute``: attribute to monitor on the given repositories. You can get the list from of valid attributes from the type db in ``resources/collectdcvmfs.db``.
+* ``Interval``: interval in seconds to probe the CVMFS repositories.
+
+Metrics
+-------
+
+The metrics are published in the following structure::
+
+    Plugin: cvmfs
+    PluginInstance: <repo>
+    Type: {<Attribute>|MountTime|Memory}
+    
+    # Only with Memory:
+    TypeInstance: [rss|vms]
+
+
+Example::
+
+    lxplus123.cern.ch/cvmfs-lhcb.cern.ch/mounttime values=[0.000999927520751953]
+    lxplus123.cern.ch/cvmfs-lhcb.cern.ch/nioerr values=[0]
+    lxplus123.cern.ch/cvmfs-lhcb.cern.ch/memory-rss values=[31760384]

--- a/resources/collectdcvmfs.db
+++ b/resources/collectdcvmfs.db
@@ -1,0 +1,59 @@
+# Shows the time that takes to ls a repository
+mounttime value:GAUGE:0:u
+
+# Shows the memory consumed by the cvmfs process
+memory rss:GAUGE:0:u vms:GAUGE:0:u
+
+# Attributes
+# http://cvmfs.readthedocs.io/en/stable/cpt-details.html#getxattr
+
+# Shows the remaining life time of the mounted root file catalog in minutes.
+expires value:GAUGE:0:u
+
+# Like timeout but for the host settings to fetch external files.
+external_timeout value:GAUGE:0:u
+
+# Shows the highest possible inode with the current set of loaded catalogs.
+inode_max value:GAUGE:0:u
+
+# Shows the maximum number of file descriptors available to file system clients.
+maxfd value:GAUGE:0:u
+
+# Shows the number of cache cleanups in the last 24 hours.
+ncleanup24 value:GAUGE:0:u
+
+# Shows the number of currently loaded nested catalogs.
+nclg value:GAUGE:0:u
+
+# Shows the overall number of opened directories.
+ndiropen value:GAUGE:0:u
+
+# Shows the overall number of downloaded files since mounting.
+ndownload value:GAUGE:0:u
+
+# Shows the total number of I/O errors encoutered since mounting.
+nioerr value:GAUGE:0:u
+
+# Shows the overall number of open() calls since mounting.
+nopen value:GAUGE:0:u
+
+# Shows the file catalog revision of the mounted root catalog, an auto-increment counter increased on every repository publish.
+revision value:GAUGE:0:u
+
+# Shows the overall amount of downloaded kilobytes.
+rx value:GAUGE:0:u
+
+# Shows the average download speed.
+speed value:GAUGE:0:u
+
+# Shows the timeout for proxied connections in seconds.
+timeout value:GAUGE:0:u
+
+# Shows the timeout for direct connections in seconds.
+timeout_direct  value:GAUGE:0:u
+
+# Shows the time passed since mounting in minutes.
+uptime value:GAUGE:0:u
+
+# Shows the number of file descriptors currently issued to file system clients.
+usedfd value:GAUGE:0:u

--- a/setup.py
+++ b/setup.py
@@ -5,34 +5,35 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
-
 version = '0.1'
 
 install_requires = [
-    # List your project dependencies here.
-    # For more details, see:
-    # http://packages.python.org/distribute/setuptools.html#declaring-dependencies
+    'xattr',
+    'psutil'
 ]
 
 
-setup(name='collectd-cvmfs',
+setup(name='collectdcvmfs',
     version=version,
     description="Collectd Plugin to Monitor CvmFS Clients",
     long_description=README + '\n\n' + NEWS,
+    long_description_content_type="text/x-rst",
     classifiers=[
-      # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: System Administrators",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python",
+        "Topic :: System :: Monitoring",
     ],
     keywords='collectd cvmfs monitoring',
-    author='Louis Fenandez Alvarez',
-    author_email='louis.fernandez.alvarez@cern.ch',
+    author='Luis Fenandez Alvarez',
+    author_email='luis.fernandez.alvarez@cern.ch',
     url='https://github.com/cvmfs/collectd-cvmfs',
     license='Apache II',
     packages=find_packages('src'),
-    package_dir = {'': 'src'},include_package_data=True,
+    package_dir = {'': 'src'},
+    data_files = [('/usr/share/collectd/', ['resources/collectdcvmfs.db'])],
+    include_package_data=True,
     zip_safe=False,
-    install_requires=install_requires,
-    entry_points={
-        'console_scripts':
-            ['collectd-cvmfs=collectdcvmfs:main']
-    }
+    install_requires=install_requires
 )

--- a/src/collectdcvmfs/__init__.py
+++ b/src/collectdcvmfs/__init__.py
@@ -1,4 +1,90 @@
-# Example package with a console entry point
+import collectd
+import xattr
+import os
+import psutil
+import time
 
-def main():
-    print "Hello World"
+
+CVMFS_ROOT = '/cvmfs'
+PLUGIN_NAME = 'cvmfs'
+
+
+def read_mounttime(repo_mountpoint):
+    start = time.time()
+    os.listdir(repo_mountpoint)
+    end = time.time()
+    return end - start
+
+def read():
+    val = collectd.Values(plugin=PLUGIN_NAME)
+    for repo in REPOS:
+        val.plugin_instance = repo
+        repo_mountpoint = os.path.join(CVMFS_ROOT, repo)
+
+        if MOUNTTIME:
+            try:
+                val.dispatch(type='mounttime', values=[read_mounttime(repo_mountpoint)])
+            except Exception:
+                collectd.warning('cvmfs: failed to get MountTime for repo %s' % repo)
+
+        if MEMORY:
+            try:
+                repo_pid = int(xattr.getxattr(repo_mountpoint, 'user.pid'))
+                repo_mem = psutil.Process(repo_pid).get_memory_info()
+                val.dispatch(type='memory', type_instance='rss', values=[repo_mem.rss])
+                val.dispatch(type='memory', type_instance='vms', values=[repo_mem.vms])
+            except Exception:
+                collectd.warning('cvmfs: failed to get Memory for repo %s' % repo)
+
+        for attribute in ATTRIBUTES:
+            attribute_name = "user.%s" % attribute
+            try:
+                val.dispatch(type=attribute, values=[float(xattr.getxattr(repo_mountpoint, attribute_name))])
+            except Exception:
+                collectd.warning('cvmfs: failed to inspect attribute "%s" in  repo "%s"' % (attribute_name, repo_mountpoint))
+
+
+def str2bool(boolstr):
+    if boolstr.lower() == 'true':
+        return True
+    elif boolstr.lower() == 'false':
+        return False
+    else:
+        raise TypeError('Boolean value expected.')
+
+
+def configure(conf):
+    global REPOS, ATTRIBUTES, MEMORY, MOUNTTIME
+    REPOS = []
+    ATTRIBUTES = []
+    MEMORY = True
+    MOUNTTIME = True
+    for node in conf.children:
+        key = node.key.lower()
+        if key == 'repo':
+            REPOS += node.values
+        elif key == 'attribute':
+            ATTRIBUTES += node.values
+        elif key == 'memory':
+            try:
+                MEMORY = str2bool(node.values[0])
+            except:
+                collectd.info("cvmfs: Memory value %s is not valid. It must be either True or False" % (node.values[0]))
+        elif key == 'mounttime':
+            try:
+                MOUNTTIME = str2bool(node.values[0])
+            except:
+                collectd.info("cvmfs: MountTime value %s is not valid. It must be either True or False" % (node.values[0]))
+        elif key == 'interval':
+            interval=int(node.values[0])
+
+    try:
+        collectd.register_read(read, interval)
+    except NameError:
+        collectd.register_read(read)
+
+    collectd.info("cvmfs: plugin configured to monitor %s in %s using %s." % (ATTRIBUTES, REPOS, "%ss interval" % interval if 'interval' in locals() else "global interval"))
+
+
+collectd.register_config(configure)
+


### PR DESCRIPTION
PR to with the first implementation. It provides:
* Custom `Interval` to probe the repos.
* `MountTime` option to get the time it takes to list the contents of the repo.
* `Memory` option to get the rss/vms memory metrics of each repo.
* `Attribute` option to specify the list of attributes to probe among the valid ones.
* `Repo` option to restrict which CVMFS repositories are monitored.

In its current form the only external dependencies are: `xattrs` and `psutil`.

Some settings of the python setup configuration has been updated as well. 

Looks ready for proper testing to me...