### PR TITLE
Fix memory metric to provide type-instance instead of multiple values

### DIFF
--- a/resources/collectdcvmfs.db
+++ b/resources/collectdcvmfs.db
@@ -2,7 +2,8 @@
 mounttime value:GAUGE:0:u
 
 # Shows the memory consumed by the cvmfs process
-memory rss:GAUGE:0:u vms:GAUGE:0:u
+memory rss:GAUGE:0:u
+memory vms:GAUGE:0:u
 
 # Attributes
 # http://cvmfs.readthedocs.io/en/stable/cpt-details.html#getxattr


### PR DESCRIPTION
I don't know why/how I missed this while testing but:

Without this patch, memory metrics are not working as it should be reported like `val.dispatch(type='memory', values=[repo_mem.rss, repo_mem.vms])` and values would end up in the DS fields of the metrics. However, we're are reporting things in two calls with different type-instance.

This patch fixes the Memory type definition to allow the current behaviour.