### PR TITLE
WiP: Add unit tests to the plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ develop-eggs
 tmp
 build
 dist
+
+.pytest_cache
+.tox

--- a/HACKING.txt
+++ b/HACKING.txt
@@ -6,6 +6,9 @@ To create a buildout,
   $ python bootstrap.py
   $ bin/buildout
 
+When running tox, some of the dependencies for the virtual environment require Development
+packages to compile the python packages.
+
 Release HOWTO
 =============
 

--- a/src/collectd_cvmfs/__init__.py
+++ b/src/collectd_cvmfs/__init__.py
@@ -8,6 +8,10 @@ import time
 CVMFS_ROOT = '/cvmfs'
 PLUGIN_NAME = 'cvmfs'
 
+CONFIG_DEFAULT_REPOS = []
+CONFIG_DEFAULT_ATTRIBUTES = []
+CONFIG_DEFAULT_MEMORY = True
+CONFIG_DEFAULT_MOUNTTIME = True
 
 def read_mounttime(repo_mountpoint):
     start = time.time()
@@ -55,10 +59,10 @@ def str2bool(boolstr):
 
 def configure(conf):
     global REPOS, ATTRIBUTES, MEMORY, MOUNTTIME
-    REPOS = []
-    ATTRIBUTES = []
-    MEMORY = True
-    MOUNTTIME = True
+    REPOS = CONFIG_DEFAULT_REPOS
+    ATTRIBUTES = CONFIG_DEFAULT_ATTRIBUTES
+    MEMORY = CONFIG_DEFAULT_MEMORY
+    MOUNTTIME = CONFIG_DEFAULT_MOUNTTIME
     for node in conf.children:
         key = node.key.lower()
         if key == 'repo':

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+pytest
+mock
+decorator

--- a/tests/test_collectd_cvmfs.py
+++ b/tests/test_collectd_cvmfs.py
@@ -1,0 +1,125 @@
+import sys
+
+import pytest
+from mock import MagicMock, Mock, mock_open, patch
+
+configure_data = [
+    (["ams.cern.ch"], ["nioerr"], True, True, 200),
+    (["alice.cern.ch", "atlas.cern.ch", "cms.cern.cn"], ["ndownload", "nioerr", "usedfd"], False, False, 200)
+]
+
+MOCK_METRICS_XATTR = 2
+MOCK_METRICS_MOUNTTIME = 0.1
+MOCK_METRICS_MEM_RSS = 1000
+MOCK_METRICS_MEM_VMS = 2000
+
+@pytest.fixture
+def collectd_cvmfs():
+    collectd = MagicMock()
+    with patch.dict('sys.modules', {'collectd': collectd}):
+        import collectd_cvmfs
+        yield collectd_cvmfs
+
+@pytest.fixture
+def config():
+    pass
+
+def test_configure_defaults(collectd_cvmfs):
+    collectd_cvmfs.configure(Mock(children = []))
+
+    assert collectd_cvmfs.REPOS == collectd_cvmfs.CONFIG_DEFAULT_REPOS
+    assert collectd_cvmfs.ATTRIBUTES == collectd_cvmfs.CONFIG_DEFAULT_ATTRIBUTES
+    assert collectd_cvmfs.MEMORY == collectd_cvmfs.CONFIG_DEFAULT_MEMORY
+    assert collectd_cvmfs.MOUNTTIME == collectd_cvmfs.CONFIG_DEFAULT_MOUNTTIME
+
+    collectd_cvmfs.collectd.register_read.assert_called_once_with(collectd_cvmfs.read)
+
+@pytest.mark.parametrize("repos,attributes,memory,mounttime,interval", configure_data)
+def test_configure_single_ok(collectd_cvmfs, repos, attributes, memory, mounttime, interval):
+    # TODO: Simplify/fixturize the config init logic
+    config = Mock()
+    config.children = [
+        Mock(key = 'Repo', values = repos),
+        Mock(key = 'Attribute', values = attributes),
+        Mock(key = 'Memory', values = [str(memory)]),
+        Mock(key = 'MountTime', values = [str(mounttime)]),
+        Mock(key = 'Interval', values=[str(interval)])
+    ]
+
+    collectd_cvmfs.configure(config)
+
+    assert collectd_cvmfs.REPOS == repos
+    assert collectd_cvmfs.ATTRIBUTES == attributes
+    assert collectd_cvmfs.MEMORY == memory
+    assert collectd_cvmfs.MOUNTTIME == mounttime
+
+    collectd_cvmfs.collectd.register_read.assert_called_once_with(collectd_cvmfs.read, interval)
+
+@pytest.mark.parametrize("repos,attributes,memory,mounttime,interval", configure_data)
+def test_configure_multiple_ok(collectd_cvmfs, repos, attributes, memory, mounttime, interval):
+    # TODO: Simplify/fixturize the config init logic
+    config = Mock()
+    config.children = [Mock(key = 'Repo', values = [repo]) for repo in repos] + \
+        [Mock(key = 'Attribute', values = [attr]) for attr in attributes] + \
+        [Mock(key = 'Memory', values = [str(memory)]),
+        Mock(key = 'MountTime', values = [str(mounttime)]),
+        Mock(key = 'Interval', values=[str(interval)])]
+
+    collectd_cvmfs.configure(config)
+
+    assert collectd_cvmfs.REPOS == repos
+    assert collectd_cvmfs.ATTRIBUTES == attributes
+    assert collectd_cvmfs.MEMORY == memory
+    assert collectd_cvmfs.MOUNTTIME == mounttime
+
+    collectd_cvmfs.collectd.register_read.assert_called_once_with(collectd_cvmfs.read, interval)
+
+
+@pytest.mark.parametrize("strvalue,boolvalue", [("True", True), ("tRue", True), ("false", False), ("False", False)])
+def test_str2bool_valid(collectd_cvmfs, strvalue, boolvalue):
+    assert collectd_cvmfs.str2bool(strvalue) == boolvalue
+
+
+@pytest.mark.parametrize("strvalue", [("Si"), ("On"), ("Off"), ("Noooo")])
+def test_str2bool_invalid(collectd_cvmfs, strvalue):
+    with pytest.raises(TypeError):
+        collectd_cvmfs.str2bool(strvalue)
+
+
+def test_read_empty(collectd_cvmfs):
+    collectd_cvmfs.configure(Mock(children = []))
+    with patch('collectd.Values') as val_mock:
+        collectd_cvmfs.read()
+        val_mock.return_value.assert_not_called()
+
+
+@pytest.mark.parametrize("repos,attributes,memory,mounttime,interval", configure_data)
+def test_read_ok(collectd_cvmfs, repos, attributes, memory, mounttime, interval):
+    # TODO: Simplify/fixturize the config init logic
+    config = Mock()
+    config.children = [
+        Mock(key = 'Repo', values = repos),
+        Mock(key = 'Attribute', values = attributes),
+        Mock(key = 'Memory', values = [str(memory)]),
+        Mock(key = 'MountTime', values = [str(mounttime)]),
+        Mock(key = 'Interval', values=[str(interval)])
+    ]
+
+    collectd_cvmfs.configure(config)
+
+    with patch('collectd_cvmfs.read_mounttime', return_value=MOCK_METRICS_MOUNTTIME):
+        with patch('xattr.getxattr', return_value=str(MOCK_METRICS_XATTR)):
+            with patch('psutil.Process') as psutil_mock:
+                with patch('collectd.Values') as val_mock:
+                    psutil_mock.return_value.get_memory_info.return_value = Mock(rss=MOCK_METRICS_MEM_RSS, vms=MOCK_METRICS_MEM_VMS)
+                    collectd_cvmfs.read()
+
+                    collectd_cvmfs.collectd.Values.assert_called_once_with(plugin=collectd_cvmfs.PLUGIN_NAME)
+                    if mounttime:
+                        val_mock.return_value.dispatch.assert_any_call(type='mounttime', values=[MOCK_METRICS_MOUNTTIME])
+                    if memory:
+                        psutil_mock.assert_any_call(MOCK_METRICS_XATTR)
+                        val_mock.return_value.dispatch.assert_any_call(type='memory', type_instance='rss', values=[MOCK_METRICS_MEM_RSS])
+                        val_mock.return_value.dispatch.assert_any_call(type='memory', type_instance='vms', values=[MOCK_METRICS_MEM_VMS])
+                    for attr in attributes:
+                        val_mock.return_value.dispatch.assert_any_call(type=attr, values=[MOCK_METRICS_XATTR])

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py26,py27,py35
+
+[testenv]
+changedir=tests
+deps =
+    -rtest-requirements.txt
+commands=pytest -vv
+
+recreate = True


### PR DESCRIPTION
This is getting close to be ready so I open the pull request to get a bit of feedback and polish the tests before merging.

Things I don't like / fail:

- [ ] I would like to _fixturize_ the config initialization.
- [ ] I will move part of the patching logic from the test case to the `collectd_cvmfs` fixture.
- [ ] The tests are failing on `py26` because of the file `/usr/share/collectd` tried to be installed as a standard user, py27 py35 both are fine.