### PR TITLE
Fix #9 - remove memory type definition

### DIFF
--- a/resources/collectd_cvmfs.db
+++ b/resources/collectd_cvmfs.db
@@ -1,10 +1,6 @@
 # Shows the time that takes to ls a repository
 mounttime value:GAUGE:0:u
 
-# Shows the memory consumed by the cvmfs process
-memory rss:GAUGE:0:u
-memory vms:GAUGE:0:u
-
 # Attributes
 # http://cvmfs.readthedocs.io/en/stable/cpt-details.html#getxattr
 


### PR DESCRIPTION
This pull request fixes #9 

The `memory` type is already define as a built-in in collectd, so there is no need to redefine it.

Even if it wasn't there, this definition is wrong as it doesn't match the pattern used by the plugin:
* The plugin plublishes `<host>/cvmfs-<repo>/memory-rss` and "rss" is an instance of the type and not a datasource as this definition was wrongly expressing.