### PR TITLE
Fix #8 - Rewrite mounttime metric probing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,5 @@ develop-eggs
 tmp
 build
 dist
-
 .pytest_cache
 .tox

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,7 @@ Example::
         Repo "ams.cern.ch"
 
         MountTime True
+        MountTimeout 10
         Memory True
 
         Attribute ndownload nioerr
@@ -31,6 +32,7 @@ Example::
 * ``TypesDB``: types used by the plugin and shipped with the package. 
 * ``Repo``: cvmfs repository to monitor.
 * ``MountTime``: boolean value to specify whether mount time should be reported or not.
+* ``MountTimeout``: timeout in seconds while trying to mount the repositories.
 * ``Memory``: boolean value to specify whether the memory footprint should be reported or not.
 * ``Attribute``: attribute to monitor on the given repositories. You can get the list from of valid attributes from the type db in ``resources/collectd_cvmfs.db``.
 * ``Interval``: interval in seconds to probe the CVMFS repositories.
@@ -45,14 +47,14 @@ The metrics are published in the following structure::
 
     Plugin: cvmfs
     PluginInstance: <repo>
-    Type: {<Attribute>|MountTime|Memory}
+    Type: {<Attribute>|MountTime|Memory|Mountok}
     
     # Only with Memory:
     TypeInstance: [rss|vms]
-
 
 Example::
 
     lxplus123.cern.ch/cvmfs-lhcb.cern.ch/mounttime values=[0.000999927520751953]
     lxplus123.cern.ch/cvmfs-lhcb.cern.ch/nioerr values=[0]
     lxplus123.cern.ch/cvmfs-lhcb.cern.ch/memory-rss values=[31760384]
+    lxplus123.cern.ch/cvmfs-repo.domain.ch/mountok values=[1]

--- a/resources/collectd_cvmfs.db
+++ b/resources/collectd_cvmfs.db
@@ -1,6 +1,9 @@
 # Shows the time that takes to ls a repository
 mounttime value:GAUGE:0:u
 
+# Shows whether a mount command succeeded (1) or not (0)
+mountok value:GAUGE:0:1
+
 # Attributes
 # http://cvmfs.readthedocs.io/en/stable/cpt-details.html#getxattr
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ version = '1.1.0'
 
 install_requires = [
     'xattr',
-    'psutil'
+    'psutil',
+    'scandir;python_version<"3.5"'
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35
+envlist = py27,py34,py35
 
 [testenv]
 changedir=tests


### PR DESCRIPTION
This pull request fixes #8 and modifies a little bit the mounttime query:
* Implementation based on scandir as os.listdir cannot safely be run asynchronously when things get stuck.
* Added mounttimeout setting to kill the mount thread. It defaults to 5s.
* When the repo cannot be mounted the value of `timedout-mount` is reported as 1 (0 otherwise).