### PR TITLE
Require pyxattr rather xattr

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 version = '1.2.2'
 
 install_requires = [
-    'xattr',
+    'pyxattr',
     'psutil',
     'scandir;python_version<"3.5"'
 ]


### PR DESCRIPTION
In reality we are using the

https://pypi.org/project/pyxattr

and not

https://pypi.org/project/xattr

Note that both allow `import xattr` to work.

So we correct the metadata to reflect that. Background in

https://bugzilla.redhat.com/show_bug.cgi?id=1817425