### PR TITLE
Use fqrn attribute to check if repo really mounted

### DIFF
--- a/src/collectd_cvmfs/__init__.py
+++ b/src/collectd_cvmfs/__init__.py
@@ -63,7 +63,12 @@ class CvmfsProbe(object):
         start = time.time()
         self.safe_scandir(repo_mountpoint, timeout)
         end = time.time()
-        return end - start
+        # Did we really mount it ?
+        try:
+          xattr.getxattr(repo_mountpoint, 'user.fqrn') == repo_mountpoint
+          return end - start
+        except:
+          raise Exception("Repository was not mounted correctly")
 
 
     def read(self, config):


### PR DESCRIPTION
Rather than relying on scandir only to check if repository
is mounted actually check an attribute.

```
[ "x$(attr -qg fqrn /cvmfs/cms.cern.ch)" = "xcms.cern.ch" ]
```

This avoids having to solve the problem in #14