### PR TITLE
Continue with the next available repo if issue with current

### DIFF
--- a/src/collectd_cvmfs/__init__.py
+++ b/src/collectd_cvmfs/__init__.py
@@ -94,6 +94,7 @@ class CvmfsProbe(object):
             except Exception as e:
                 collectd.warning('cvmfs: failed to get MountTime for repo %s: %s' % (repo, e))
                 val.dispatch(type='mountok', values=[0], interval=config.interval)
+                continue
 
             if config.memory:
                 try:
@@ -102,6 +103,9 @@ class CvmfsProbe(object):
                     val.dispatch(type='memory', type_instance='vms', values=[repo_mem.vms], interval=config.interval)
                 except Exception:
                     collectd.warning('cvmfs: failed to get Memory for repo %s' % repo)
+                    val.dispatch(type='memory', type_instance='rss', values=[0], interval=config.interval)
+                    val.dispatch(type='memory', type_instance='vms', values=[0], interval=config.interval)
+                    continue
 
             for attribute in config.attributes:
                 attribute_name = "user.%s" % attribute


### PR DESCRIPTION
Currently, if any of the CVMFS repos has issues and MountTime raises an alarm, the script continues with the same repo and checks the memory, which hangs forever. 

Instead, in the case when an exception is raised while checking the mount time, just continue with the next CVMFS repo in the list (after the exception is raised).

Likewise, if an exception is raised when checking the memory of a mounted repo (the user.pid), also continue with the next repo in the list after raising an exception with values 0 both for RSS and VMS memories.